### PR TITLE
Add VuePress docs framework

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy VuePress site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm run docs:build
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/.vuepress/dist
+          force_orphan: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+docs/.vuepress/dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# blackcrescent
+# Black Crescent Documentation
+
+This repository hosts the source for a VuePress site. Clone the repository and drop your Markdown file into the `docs/` directory. The sidebar will be generated automatically from your headings.
+
+## Local development
+
+1. Install dependencies (requires Node.js):
+   ```sh
+   npm install
+   ```
+2. Start a local server:
+   ```sh
+   npm run docs:dev
+   ```
+3. Open `http://localhost:8080` to preview the site.
+
+## Building for GitHub Pages
+
+Run the build command and push the contents of `docs/.vuepress/dist` to the `gh-pages` branch or deploy using GitHub Actions:
+
+```sh
+npm run docs:build
+```
+
+GitHub Pages should be configured to serve from the `/blackcrescent/` base path.

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  base: '/blackcrescent/',
+  title: 'Black Crescent Docs',
+  description: 'Rules for Beyblade X',
+  themeConfig: {
+    sidebar: 'auto',
+    nav: [
+      { text: 'Home', link: '/' }
+    ]
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Rules for Beyblade X
+
+Welcome to the Black Crescent documentation. Replace this file with your Markdown export from Google Docs to render it with VuePress.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "blackcrescent",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "docs:dev": "vuepress dev docs",
+    "docs:build": "vuepress build docs"
+  },
+  "devDependencies": {
+    "vuepress": "^1.9.9"
+  }
+}


### PR DESCRIPTION
## Summary
- add VuePress config and placeholder docs
- create GitHub Actions workflow for deployment
- update README with instructions
- add package.json and ignore build output

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run docs:build` *(fails: vuepress not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b11c45408329a2855050d1132081