### PR TITLE
Fix GitHub Pages deploy permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure the workflow can push to the gh-pages branch by granting write permissions

## Testing
- `npm ci`
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_6862c11ce6108329aecaca03d8370da8